### PR TITLE
Added option to StatusTrigger to check if TriggerSource is an enemy/friendly GameObject

### DIFF
--- a/XIVAuras/Helpers/Enums.cs
+++ b/XIVAuras/Helpers/Enums.cs
@@ -22,6 +22,12 @@ namespace XIVAuras.Helpers
         TargetOfTarget,
         FocusTarget
     }
+
+    public enum TriggerSourceType {
+        Any,
+        Friendly,
+        Enemy
+    }
     
     public enum TriggerCond
     {


### PR DESCRIPTION
I've looked everywhere in the XIVAura config and didn't see an option to trigger an aura for only friendly units or enemy units. My use case is: as a healer, I want an aura that tells me if my target is missing my DoT, _BUT only_ if the target is an enemy unit. Currently, if I switch off to cast an action on a friendly target, my DoT aura shows up even though they are a friendly target (and I cant use Combust III on a friendly unit lol).

I'm not attached to any of the nomenclature or terminology I used, so if you feel this is a good change but don't like the wording I used, just let me know and I'll change it.

Below are example screenshots of the config and an aura that only triggers when I target an enemy. If the `TriggerSource` is `Player`, then the config option is hidden and ignored to prevent weird behavior.
**Enemy Targeted**
![EnemyTargetted](https://user-images.githubusercontent.com/908648/153295818-dfe26f43-8a54-4324-9718-b6e1eb087ac8.png)

**Friendly Target** (Aura should not be triggered)
![FriendlyTargetted](https://user-images.githubusercontent.com/908648/153295831-f48a4654-1dcd-4ffc-8434-ee1aa5562205.png)

