### PR TITLE
Update for patch 6.2

### DIFF
--- a/XIVAuras/Config/StatusTrigger.cs
+++ b/XIVAuras/Config/StatusTrigger.cs
@@ -86,7 +86,7 @@ namespace XIVAuras.Config
                 foreach (var status in statusList)
                 {
                     if (status is not null &&
-                        (status.SourceID == player.ObjectId || !this.OnlyMine))
+                        (status.SourceId == player.ObjectId || !this.OnlyMine))
                     {
                         active = true;
                         data.Id = status.StatusId;

--- a/XIVAuras/Plugin.cs
+++ b/XIVAuras/Plugin.cs
@@ -26,7 +26,7 @@ namespace XIVAuras
     {
         public const string ConfigFileName = "XIVAuras.json";
 
-        public static string Version { get; private set; } = "0.2.3.1";
+        public static string Version { get; private set; } = "0.2.4.0";
 
         public static string ConfigFileDir { get; private set; } = "";
 

--- a/XIVAuras/XIVAuras.csproj
+++ b/XIVAuras/XIVAuras.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup Label="Target">
         <PlatformTarget>x64</PlatformTarget>
-        <TargetFramework>net5.0-windows</TargetFramework>
+        <TargetFramework>net6.0-windows</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Platforms>x64</Platforms>
         <Configurations>Debug;Release</Configurations>
@@ -10,9 +10,9 @@
     <!-- Assembly Configuration -->
     <PropertyGroup>
         <AssemblyName>XIVAuras</AssemblyName>
-        <AssemblyVersion>0.2.3.1</AssemblyVersion>
-        <FileVersion>0.2.3.1</FileVersion>
-        <InformationalVersion>0.2.3.1</InformationalVersion>
+        <AssemblyVersion>0.2.4.0</AssemblyVersion>
+        <FileVersion>0.2.4.0</FileVersion>
+        <InformationalVersion>0.2.4.0</InformationalVersion>
     </PropertyGroup>
 
     <!-- Build Configuration -->
@@ -86,7 +86,7 @@
 
     <!-- NuGet Packages -->
     <ItemGroup>
-        <PackageReference Include="DalamudPackager" Version="2.1.7" />
+        <PackageReference Include="DalamudPackager" Version="2.1.8" />
     </ItemGroup>
 
     <!-- Dalamud Packager Task-->

--- a/XIVAuras/changelog.md
+++ b/XIVAuras/changelog.md
@@ -1,3 +1,7 @@
+# Version 0.2.4.0
+- Update plug for patch 6.2
+- Target .net 6.0
+
 # Version 0.2.3.1
 - Fixed issue with auras tracking status on Target of Target or Focus Target
 - Fixed issue with status Icons not showing in certain conditions


### PR DESCRIPTION
Updates are required to make it work for patch 6.2. I've done some simple testing and the features that I utilize seem to be working fine.

- Target DalamudPackager 2.1.8
- Target .Net 6.0
- Fix property name change SourceID -> SourceId